### PR TITLE
Use seed to model; more cleanup

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,5 +21,73 @@ func TestTruncateToSentences(t *testing.T) {
 	}
 	for _, c := range testCases {
 		assert.Equal(t, c.expected, truncateToSentences(c.input, c.n))
+	}
+}
+
+func TestParseExistingSummaries(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "yaml_details_*.md")
+	assert.NoError(t, err, "failed to create temp file")
+	defer func() {
+		cerr := os.Remove(tmpFile.Name())
+		if cerr != nil {
+			assert.Fail(t, "failed to remove temp file", cerr)
+		}
+	}()
+
+	content := `# YAML File Details
+
+---
+
+## [foo/](../foo/)
+- [bar.yaml](../foo/bar.yaml): This is bar summary.
+- [baz.yaml](../foo/baz.yaml): This is baz summary.
+
+## [root/](../root/)
+- [top.yaml](../root/top.yaml): Top level summary.`
+	_, err = tmpFile.WriteString(content)
+	assert.NoError(t, err, "failed to write to temp file")
+	cerr := tmpFile.Close()
+	assert.NoError(t, cerr, "failed to close temp file")
+
+	summaries := parseExistingSummaries(tmpFile.Name())
+
+	expect := map[string]string{
+		filepath.Join("foo", "bar.yaml"):  "This is bar summary.",
+		filepath.Join("foo", "baz.yaml"):  "This is baz summary.",
+		filepath.Join("root", "top.yaml"): "Top level summary.",
+	}
+
+	assert.Equal(t, len(expect), len(summaries), "expected %d summaries, got %d", len(expect), len(summaries))
+	for k, v := range expect {
+		assert.Equal(t, v, summaries[k], "expected %q for %q, got %q", v, k, summaries[k])
+	}
+}
+
+func TestParseSummaryLines(t *testing.T) {
+	lines := []string{
+		"# YAML File Details",
+		"",
+		"---",
+		"",
+		"## [foo/](../foo/)",
+		"- [bar.yaml](../foo/bar.yaml): This is bar summary.",
+		"- [baz.yaml](../foo/baz.yaml): This is baz summary.",
+		"",
+		"## [root/](../root/)",
+		"- [top.yaml](../root/top.yaml): Top level summary.",
+	}
+
+	existing := make(map[string]string)
+	parseSummaryLines(lines, existing)
+
+	expect := map[string]string{
+		filepath.Join("foo", "bar.yaml"):  "This is bar summary.",
+		filepath.Join("foo", "baz.yaml"):  "This is baz summary.",
+		filepath.Join("root", "top.yaml"): "Top level summary.",
+	}
+
+	assert.Equal(t, len(expect), len(existing), "expected %d summaries, got %d", len(expect), len(existing))
+	for k, v := range expect {
+		assert.Equal(t, v, existing[k], "expected %q for %q, got %q", v, k, existing[k])
 	}
 }


### PR DESCRIPTION
Changes:
- Added unit testing.
- Added additional sanitization of the model output.
- Uses a seed now to prevent randomness from model.
- Broke down existing functions into better and more readable versions.

### Enhancements to summary generation:
* Introduced the `cleanSummary` function to remove markdown, lists, and breakdowns from summaries, ensuring concise plain-text output.
* Modified `summarizeYAMLFile` to use the `cleanSummary` function and updated the request structure to use `ollama.ChatRequest` for better integration with the chat API.

### Improvements to output consistency:
* Added sorting for directories and files in `writeMarkdownSummary`, ensuring alphabetically ordered summaries for better readability.

### Modularization and error handling:
* Refactored `parseExistingSummaries` by introducing `readLinesFromFile` and `parseSummaryLines` functions, improving code modularity and readability.
* Enhanced error handling in file operations by safely closing files using deferred functions with error checks. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL117-R184) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL207-R285)

### New unit tests:
* Added tests for `parseExistingSummaries` and `parseSummaryLines` to verify correct parsing of markdown summaries.