### PR TITLE
Add golangci-lint action

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -18,3 +18,8 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          args: --timeout 10m0s


### PR DESCRIPTION
This pull request introduces a small update to the `.github/workflows/pre-main.yml` file by adding a step to run `golangci-lint` as part of the CI workflow.

* [`.github/workflows/pre-main.yml`](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886R21-R25): Added a new step to execute `golangci-lint` with a 10-minute timeout in the `jobs:` section, enhancing code quality checks.