### PR TITLE
Add flag for hidden folders; README update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 .yaml_summary_cache/
 .DS_Store
 coverage/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -23,13 +23,20 @@ This will produce a binary named `readmebuilder` in the project directory.
 ```
 - `[directory]`: The root directory to recursively search for YAML files. Required.
 
-#### Example
-```
+#### Examples
+```bash
+# Basic usage - excludes hidden directories
 ./readmebuilder ./my-yaml-repo
+
+# Include hidden directories in the search
+./readmebuilder --include-hidden-directories ./my-yaml-repo
+
+# Regenerate all summaries and include hidden directories
+./readmebuilder --regenerate --include-hidden-directories ./my-yaml-repo
 ```
 
 This will:
-- Recursively find all `.yaml` and `.yml` files under `./my-yaml-repo`.
+- Recursively find all `.yaml` and `.yml` files under `./my-yaml-repo` (excluding hidden directories by default).
 - Summarize each file using the local Ollama model.
 - Write a grouped summary to `yaml_details.md` in the root of the provided directory.
 - Show a progress bar and timing information.
@@ -41,6 +48,8 @@ This will:
   Regenerate all summaries, even if they already exist in `yaml_details.md`.
 - `--localcache`  
   Write individual summaries to `.yaml_summary_cache` in the repo root for each YAML file processed.
+- `--include-hidden-directories`  
+  Include hidden directories (starting with `.`) when searching for YAML files. By default, hidden directories like `.git`, `.vscode`, etc. are skipped for performance.
 
 ### Output
 - The tool creates or updates a `yaml_details.md` file in the target directory, grouping summaries by subdirectory.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -91,3 +91,75 @@ func TestParseSummaryLines(t *testing.T) {
 		assert.Equal(t, v, existing[k], "expected %q for %q, got %q", v, k, existing[k])
 	}
 }
+
+func TestFindYAMLFilesHiddenDirectories(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir, err := os.MkdirTemp("", "test_yaml_finder_*")
+	assert.NoError(t, err, "failed to create temp dir")
+	defer func() {
+		cerr := os.RemoveAll(tmpDir)
+		if cerr != nil {
+			assert.Fail(t, "failed to remove temp dir", cerr)
+		}
+	}()
+
+	// Create test structure:
+	// tmpDir/
+	//   ├── regular.yaml
+	//   ├── regular_dir/
+	//   │   └── nested.yaml
+	//   └── .hidden/
+	//       ├── hidden.yaml
+	//       └── subdir/
+	//           └── deep.yaml
+
+	regularDir := filepath.Join(tmpDir, "regular_dir")
+	hiddenDir := filepath.Join(tmpDir, ".hidden")
+	hiddenSubdir := filepath.Join(hiddenDir, "subdir")
+
+	// Create directories
+	assert.NoError(t, os.MkdirAll(regularDir, 0755))
+	assert.NoError(t, os.MkdirAll(hiddenSubdir, 0755))
+
+	// Create YAML files
+	files := map[string]string{
+		filepath.Join(tmpDir, "regular.yaml"):    "test: regular",
+		filepath.Join(regularDir, "nested.yaml"): "test: nested",
+		filepath.Join(hiddenDir, "hidden.yaml"):  "test: hidden",
+		filepath.Join(hiddenSubdir, "deep.yaml"): "test: deep",
+	}
+
+	for filePath, content := range files {
+		assert.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+	}
+
+	// Test with includeHidden=false (default behavior)
+	yamlFiles, err := findYAMLFiles(tmpDir, false)
+	assert.NoError(t, err)
+	assert.Len(t, yamlFiles, 2, "Should find 2 files when hidden directories are excluded")
+
+	// Convert to relative paths for easier assertion
+	var relPaths []string
+	for _, file := range yamlFiles {
+		rel, _ := filepath.Rel(tmpDir, file)
+		relPaths = append(relPaths, rel)
+	}
+	assert.Contains(t, relPaths, "regular.yaml")
+	assert.Contains(t, relPaths, filepath.Join("regular_dir", "nested.yaml"))
+
+	// Test with includeHidden=true
+	yamlFiles, err = findYAMLFiles(tmpDir, true)
+	assert.NoError(t, err)
+	assert.Len(t, yamlFiles, 4, "Should find 4 files when hidden directories are included")
+
+	// Convert to relative paths for easier assertion
+	relPaths = []string{}
+	for _, file := range yamlFiles {
+		rel, _ := filepath.Rel(tmpDir, file)
+		relPaths = append(relPaths, rel)
+	}
+	assert.Contains(t, relPaths, "regular.yaml")
+	assert.Contains(t, relPaths, filepath.Join("regular_dir", "nested.yaml"))
+	assert.Contains(t, relPaths, filepath.Join(".hidden", "hidden.yaml"))
+	assert.Contains(t, relPaths, filepath.Join(".hidden", "subdir", "deep.yaml"))
+}


### PR DESCRIPTION
Adds some new functionality that will avoid hidden holders unless specified otherwise using the flag `--include-hidden-directories`.

### Feature: Include hidden directories in YAML file searches
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL43-R54): Updated the `findYAMLFiles` function to accept a new `includeHidden` parameter and skip hidden directories unless explicitly enabled. Added a new `--include-hidden-directories` flag to the CLI to toggle this behavior. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL43-R54) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR383-R388)

### Documentation: Updated usage examples and descriptions
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R39): Added examples demonstrating the new `--include-hidden-directories` flag and clarified the default behavior of excluding hidden directories. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R52)

### Tests: Validating hidden directory functionality
* [`cmd/root_test.go`](diffhunk://#diff-558a3da4e777c67907421d3d7da4d33b537fa8fba7c600b2938bb2d39fdb59faR94-R165): Added a new test, `TestFindYAMLFilesHiddenDirectories`, to verify that the `findYAMLFiles` function correctly includes or excludes hidden directories based on the `includeHidden` parameter.