### PR TITLE
Add --model parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ vet:
 
 lint:
 	@echo -e "$(CYAN)Running golangci-lint...$(RESET)"
-	if ! command -v golangci-lint &> /dev/null; then \
-		GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
-	fi
+	@if ! command -v golangci-lint &> /dev/null; then \
+		echo -e "$(YELLOW)golangci-lint not found.$(RESET)"; \
+		echo -e "$(YELLOW)Please install it (e.g., 'brew install golangci-lint' or see https://golangci-lint.run/) and re-run 'make lint'.$(RESET)"; \
+		exit 0; \
+	fi; \
 	golangci-lint run ./...
 
 test:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A CLI tool to recursively summarize YAML files in a directory using a local Olla
 
 ### Prerequisites
 - [Ollama](https://ollama.com/) must be installed and running locally.
-- The desired model (default: `llama3.2:latest`) must be available in your local Ollama instance.
+- The desired model (default: `llama3.2:latest`) must be available in your local Ollama instance. You can override the model at runtime with `--model`.
 - Go 1.25+ is required to build from source.
 
 ### Build
@@ -33,6 +33,9 @@ This will produce a binary named `readmebuilder` in the project directory.
 
 # Regenerate all summaries and include hidden directories
 ./readmebuilder --regenerate --include-hidden-directories ./my-yaml-repo
+
+# Specify a different Ollama model without recompiling
+./readmebuilder --model mistral:latest ./my-yaml-repo
 ```
 
 This will:
@@ -50,6 +53,8 @@ This will:
   Write individual summaries to `.yaml_summary_cache` in the repo root for each YAML file processed.
 - `--include-hidden-directories`  
   Include hidden directories (starting with `.`) when searching for YAML files. By default, hidden directories like `.git`, `.vscode`, etc. are skipped for performance.
+- `--model`  
+  Ollama model to use (default: `llama3.2:latest`). Example: `--model mistral:latest`.
 
 ### Output
 - The tool creates or updates a `yaml_details.md` file in the target directory, grouping summaries by subdirectory.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Keeping a collection of models for future use.
+// Keeping a collection of constants for future use.
 const (
-	ModelName           = "llama3.2:latest"
+	DefaultModelName    = "llama3.2:latest"
 	DefaultCacheDirName = ".yaml_summary_cache"
 	MarkdownFileName    = "yaml_details.md"
 	MarkdownHeader      = `# YAML File Details
@@ -38,6 +38,9 @@ This document provides an overview of all YAML files in the repository, organize
 `
 	SummarizePrompt = "Summarize the purpose of this YAML file in no more than two short, high-level sentences. Do not include any lists, breakdowns, explanations, advice, notes, or formatting. Do not use markdown. No newlines. No code sections. Only output a single, concise summary of the file's purpose, and nothing else. Stop after two sentences. If you cannot summarize in two sentences, summarize in one: \n"
 )
+
+// ModelName is configurable via the --model flag and defaults to DefaultModelName.
+var ModelName string = DefaultModelName
 
 // findYAMLFiles recursively finds all YAML files under the given directory path.
 func findYAMLFiles(dir string, includeHidden bool) ([]string, error) {
@@ -386,6 +389,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&regenerate, "regenerate", false, "Regenerate all summaries, even if they already exist in yaml_details.md")
 	rootCmd.Flags().BoolVar(&localCache, "localcache", false, "Write individual summaries to .yaml_summary_cache in the repo root. Mostly used for debugging or local development.")
 	rootCmd.Flags().BoolVar(&includeHidden, "include-hidden-directories", false, "Include hidden directories (starting with '.') when searching for YAML files")
+	rootCmd.Flags().StringVar(&ModelName, "model", DefaultModelName, "Ollama model to use (default: "+DefaultModelName+")")
 }
 
 // Execute runs the root Cobra command.


### PR DESCRIPTION
This pull request improves the usability and documentation of the CLI tool by making the Ollama model configurable at runtime and updating the related documentation and code to reflect this change. The most important changes are grouped below:

**Feature: Configurable Ollama Model**

* Added a `--model` flag to the CLI, allowing users to specify the Ollama model at runtime instead of being limited to the default. The flag defaults to `llama3.2:latest`. (`cmd/root.go`, `README.md`) [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR392) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR42-R44) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL17-R19) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R57) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R38)

**Documentation Updates**

* Updated the `README.md` to document the new `--model` flag, including usage examples and clarifying that the model can be overridden at runtime. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R38) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R57)

**Developer Experience**

* Modified the `Makefile` so that if `golangci-lint` is not installed, it now prompts the user to install it manually instead of attempting to install it automatically. This provides clearer instructions and avoids unexpected installations.