### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # yaml-to-readme
 
+![Generate Markdown](https://github.com/sebrandon1/yaml-to-readme/actions/workflows/generate-markdown.yml/badge.svg)
+![Test Incoming Changes](https://github.com/sebrandon1/yaml-to-readme/actions/workflows/pre-main.yml/badge.svg)
+![Release binaries](https://github.com/sebrandon1/yaml-to-readme/actions/workflows/release-binaries.yaml/badge.svg)
+
 A CLI tool to recursively summarize YAML files in a directory using a local Ollama model, outputting results to a structured markdown file.
 
 ## How to Use


### PR DESCRIPTION
This pull request adds status badges to the top of the `README.md` file to display the current state of key GitHub Actions workflows. These badges provide quick visual feedback on the build, test, and release status of the project.

Improvements to documentation:

* Added badges for the "Generate Markdown", "Test Incoming Changes", and "Release binaries" workflows at the top of the `README.md` to show their current status.