### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -16,8 +16,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run tests
+      - name: Run unit tests
         run: make test
+
+      - name: Run integration tests
+        run: make integration-test
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ YELLOW := \033[33m
 RED := \033[31m
 RESET := \033[0m
 
-.PHONY: vet lint test test-coverage coverage-html version info
+.PHONY: vet lint test test-coverage coverage-html integration-test version info
 
 vet:
 	@echo -e "$(CYAN)Running go vet...$(RESET)"
@@ -29,8 +29,12 @@ lint:
 	golangci-lint run ./...
 
 test:
-	@echo -e "$(CYAN)Running tests...$(RESET)"
-	go test ./...
+	@echo -e "$(CYAN)Running unit tests...$(RESET)"
+	go test -short ./...
+
+integration-test:
+	@echo -e "$(CYAN)Running integration tests...$(RESET)"
+	go test -v -run TestIntegration ./cmd/
 
 test-coverage:
 	@echo -e "$(CYAN)Running tests with coverage...$(RESET)"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ This will:
 ### Makefile Targets
 - `make vet`   — Run `go vet` on the codebase.
 - `make lint`  — Run `golangci-lint` (installs if missing).
+- `make test`  — Run unit tests.
+- `make integration-test` — Run integration tests (uses mocked Ollama client).
 - `make build` — Build the binary.
 
 ---

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,0 +1,335 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntegrationBasicFlow tests the complete flow from YAML files to markdown output.
+func TestIntegrationBasicFlow(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir, err := os.MkdirTemp("", "integration_test_*")
+	assert.NoError(t, err, "failed to create temp dir")
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	// Create test directory structure:
+	// tmpDir/
+	//   ├── config.yaml
+	//   ├── app/
+	//   │   ├── deployment.yaml
+	//   │   └── service.yaml
+	//   └── database/
+	//       └── postgres.yaml
+
+	appDir := filepath.Join(tmpDir, "app")
+	dbDir := filepath.Join(tmpDir, "database")
+	assert.NoError(t, os.MkdirAll(appDir, 0755))
+	assert.NoError(t, os.MkdirAll(dbDir, 0755))
+
+	// Create test YAML files with identifiable content
+	testFiles := map[string]string{
+		filepath.Join(tmpDir, "config.yaml"):     "apiVersion: v1\nkind: ConfigMap\nname: app-config",
+		filepath.Join(appDir, "deployment.yaml"): "apiVersion: apps/v1\nkind: Deployment\nname: web-app",
+		filepath.Join(appDir, "service.yaml"):    "apiVersion: v1\nkind: Service\nname: web-service",
+		filepath.Join(dbDir, "postgres.yaml"):    "apiVersion: v1\nkind: StatefulSet\nname: postgres-db",
+	}
+
+	for filePath, content := range testFiles {
+		assert.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+	}
+
+	// Create mock client with specific responses for each file
+	mockClient := NewMockOllamaClient()
+	mockClient.MockResponses = map[string]string{
+		"kind: ConfigMap":   "This YAML file defines a ConfigMap for application configuration. It stores key-value pairs for the application.",
+		"kind: Deployment":  "This YAML file defines a Kubernetes Deployment for the web application. It manages the desired state of application pods.",
+		"kind: Service":     "This YAML file defines a Kubernetes Service for network access. It exposes the application to other services.",
+		"kind: StatefulSet": "This YAML file defines a StatefulSet for PostgreSQL database. It manages stateful database instances with persistent storage.",
+	}
+
+	// Find YAML files
+	yamlFiles, err := findYAMLFiles(tmpDir, false)
+	assert.NoError(t, err)
+	assert.Len(t, yamlFiles, 4, "Should find 4 YAML files")
+
+	// Process files with mock client
+	summaries, processed, skipped := processYAMLFiles(yamlFiles, tmpDir, make(map[string]string), mockClient, false)
+	assert.Equal(t, 4, processed, "Should process 4 files")
+	assert.Equal(t, 0, skipped, "Should skip 0 files")
+	assert.Len(t, summaries, 4, "Should have 4 summaries")
+
+	// Group and write markdown
+	grouped := groupSummariesByDir(yamlFiles, summaries, tmpDir)
+	assert.NoError(t, writeMarkdownSummary(tmpDir, grouped))
+
+	// Read and verify the generated markdown
+	mdPath := filepath.Join(tmpDir, MarkdownFileName)
+	content, err := os.ReadFile(mdPath)
+	assert.NoError(t, err)
+	mdContent := string(content)
+
+	// Verify structure
+	assert.Contains(t, mdContent, "# YAML File Details")
+	assert.Contains(t, mdContent, "## [./](.././)") // Root directory
+	assert.Contains(t, mdContent, "## [app/](../app/)")
+	assert.Contains(t, mdContent, "## [database/](../database/)")
+
+	// Verify file entries
+	assert.Contains(t, mdContent, "[config.yaml](.././config.yaml)")
+	assert.Contains(t, mdContent, "[deployment.yaml](../app/deployment.yaml)")
+	assert.Contains(t, mdContent, "[service.yaml](../app/service.yaml)")
+	assert.Contains(t, mdContent, "[postgres.yaml](../database/postgres.yaml)")
+
+	// Verify summaries are present
+	assert.Contains(t, mdContent, "ConfigMap for application configuration")
+	assert.Contains(t, mdContent, "Deployment for the web application")
+	assert.Contains(t, mdContent, "Service for network access")
+	assert.Contains(t, mdContent, "StatefulSet for PostgreSQL database")
+}
+
+// TestIntegrationRegenerateFlag tests the --regenerate flag functionality.
+func TestIntegrationRegenerateFlag(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "integration_test_regenerate_*")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	// Create a single YAML file
+	testFile := filepath.Join(tmpDir, "test.yaml")
+	assert.NoError(t, os.WriteFile(testFile, []byte("test: data"), 0644))
+
+	mockClient := NewMockOllamaClient()
+	mockClient.DefaultResponse = "First summary."
+
+	// First run: generate summaries
+	yamlFiles, err := findYAMLFiles(tmpDir, false)
+	assert.NoError(t, err)
+	summaries, processed, _ := processYAMLFiles(yamlFiles, tmpDir, make(map[string]string), mockClient, false)
+	assert.Equal(t, 1, processed)
+	grouped := groupSummariesByDir(yamlFiles, summaries, tmpDir)
+	assert.NoError(t, writeMarkdownSummary(tmpDir, grouped))
+
+	// Parse existing summaries
+	mdPath := filepath.Join(tmpDir, MarkdownFileName)
+	existingSummaries := parseExistingSummaries(mdPath)
+	assert.Len(t, existingSummaries, 1)
+	assert.Contains(t, existingSummaries["test.yaml"], "First summary")
+
+	// Second run: without regenerate flag (should skip)
+	_, processed, skipped := processYAMLFiles(yamlFiles, tmpDir, existingSummaries, mockClient, false)
+	assert.Equal(t, 0, processed, "Should process 0 files (all skipped)")
+	assert.Equal(t, 1, skipped, "Should skip 1 file")
+
+	// Third run: with regenerate flag (should reprocess)
+	mockClient.DefaultResponse = "Second summary."
+	summaries, processed, skipped = processYAMLFiles(yamlFiles, tmpDir, existingSummaries, mockClient, true)
+	assert.Equal(t, 1, processed, "Should process 1 file (regenerate)")
+	assert.Equal(t, 0, skipped, "Should skip 0 files")
+	assert.Contains(t, summaries[testFile], "Second summary")
+}
+
+// TestIntegrationHiddenDirectories tests the --include-hidden-directories flag.
+func TestIntegrationHiddenDirectories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "integration_test_hidden_*")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	// Create structure with hidden directory
+	hiddenDir := filepath.Join(tmpDir, ".hidden")
+	assert.NoError(t, os.MkdirAll(hiddenDir, 0755))
+
+	regularFile := filepath.Join(tmpDir, "regular.yaml")
+	hiddenFile := filepath.Join(hiddenDir, "hidden.yaml")
+	assert.NoError(t, os.WriteFile(regularFile, []byte("regular: data"), 0644))
+	assert.NoError(t, os.WriteFile(hiddenFile, []byte("hidden: data"), 0644))
+
+	mockClient := NewMockOllamaClient()
+	mockClient.DefaultResponse = "Test summary."
+
+	// Without hidden directories
+	yamlFiles, err := findYAMLFiles(tmpDir, false)
+	assert.NoError(t, err)
+	assert.Len(t, yamlFiles, 1, "Should find 1 file (hidden excluded)")
+
+	summaries, _, _ := processYAMLFiles(yamlFiles, tmpDir, make(map[string]string), mockClient, false)
+	grouped := groupSummariesByDir(yamlFiles, summaries, tmpDir)
+	assert.NoError(t, writeMarkdownSummary(tmpDir, grouped))
+
+	mdPath := filepath.Join(tmpDir, MarkdownFileName)
+	content, err := os.ReadFile(mdPath)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(content), ".hidden", "Should not include hidden directory")
+
+	// With hidden directories
+	yamlFiles, err = findYAMLFiles(tmpDir, true)
+	assert.NoError(t, err)
+	assert.Len(t, yamlFiles, 2, "Should find 2 files (hidden included)")
+
+	summaries, _, _ = processYAMLFiles(yamlFiles, tmpDir, make(map[string]string), mockClient, false)
+	grouped = groupSummariesByDir(yamlFiles, summaries, tmpDir)
+	assert.NoError(t, writeMarkdownSummary(tmpDir, grouped))
+
+	content, err = os.ReadFile(mdPath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), ".hidden", "Should include hidden directory")
+}
+
+// TestIntegrationMarkdownFormat tests that the markdown output format is correct.
+func TestIntegrationMarkdownFormat(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "integration_test_format_*")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	// Create multiple files in different directories
+	subdir1 := filepath.Join(tmpDir, "alpha")
+	subdir2 := filepath.Join(tmpDir, "beta")
+	assert.NoError(t, os.MkdirAll(subdir1, 0755))
+	assert.NoError(t, os.MkdirAll(subdir2, 0755))
+
+	files := map[string]string{
+		filepath.Join(subdir1, "a.yaml"): "test: a",
+		filepath.Join(subdir1, "b.yaml"): "test: b",
+		filepath.Join(subdir2, "c.yaml"): "test: c",
+	}
+
+	for path, content := range files {
+		assert.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+
+	mockClient := NewMockOllamaClient()
+	mockClient.DefaultResponse = "Summary for testing."
+
+	yamlFiles, err := findYAMLFiles(tmpDir, false)
+	assert.NoError(t, err)
+
+	summaries, _, _ := processYAMLFiles(yamlFiles, tmpDir, make(map[string]string), mockClient, false)
+	grouped := groupSummariesByDir(yamlFiles, summaries, tmpDir)
+	assert.NoError(t, writeMarkdownSummary(tmpDir, grouped))
+
+	mdPath := filepath.Join(tmpDir, MarkdownFileName)
+	content, err := os.ReadFile(mdPath)
+	assert.NoError(t, err)
+	lines := strings.Split(string(content), "\n")
+
+	// Verify header is present
+	assert.Contains(t, lines[0], "# YAML File Details")
+
+	// Verify directories are sorted alphabetically
+	alphaIdx := -1
+	betaIdx := -1
+	for i, line := range lines {
+		if strings.Contains(line, "## [alpha/]") {
+			alphaIdx = i
+		}
+		if strings.Contains(line, "## [beta/]") {
+			betaIdx = i
+		}
+	}
+	assert.Greater(t, alphaIdx, 0, "Should find alpha directory")
+	assert.Greater(t, betaIdx, 0, "Should find beta directory")
+	assert.Less(t, alphaIdx, betaIdx, "Directories should be sorted alphabetically")
+
+	// Verify files within directory are sorted
+	aFileIdx := -1
+	bFileIdx := -1
+	for i := alphaIdx; i < len(lines) && i < betaIdx; i++ {
+		if strings.Contains(lines[i], "[a.yaml]") {
+			aFileIdx = i
+		}
+		if strings.Contains(lines[i], "[b.yaml]") {
+			bFileIdx = i
+		}
+	}
+	assert.Greater(t, aFileIdx, alphaIdx, "Should find a.yaml")
+	assert.Greater(t, bFileIdx, alphaIdx, "Should find b.yaml")
+	assert.Less(t, aFileIdx, bFileIdx, "Files should be sorted alphabetically")
+}
+
+// TestIntegrationSummaryCleaning tests that summaries are properly cleaned and truncated.
+func TestIntegrationSummaryCleaning(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "integration_test_cleaning_*")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	testFile := filepath.Join(tmpDir, "test.yaml")
+	assert.NoError(t, os.WriteFile(testFile, []byte("test: data"), 0644))
+
+	mockClient := NewMockOllamaClient()
+	// Simulate a response with markdown, lists, and extra sentences
+	mockClient.DefaultResponse = `# Summary
+- This is a bullet point
+This is sentence one. This is sentence two. This is sentence three. This is sentence four.
+* Another list item
+**Bold text here**`
+
+	summary, err := summarizeYAMLFile(context.Background(), mockClient, testFile)
+	assert.NoError(t, err)
+
+	// Verify cleaning and truncation
+	assert.NotContains(t, summary, "#", "Should not contain markdown headers")
+	assert.NotContains(t, summary, "**", "Should not contain bold markdown")
+	assert.NotContains(t, summary, "-", "Should not contain list markers")
+	assert.NotContains(t, summary, "*", "Should not contain asterisk list markers")
+
+	// Count sentences (should be truncated to 2)
+	sentenceCount := strings.Count(summary, ".")
+	assert.LessOrEqual(t, sentenceCount, 2, "Should have at most 2 sentences")
+}
+
+// TestIntegrationEmptyDirectory tests handling of directories with no YAML files.
+func TestIntegrationEmptyDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "integration_test_empty_*")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	mockClient := NewMockOllamaClient()
+
+	yamlFiles, err := findYAMLFiles(tmpDir, false)
+	assert.NoError(t, err)
+	assert.Len(t, yamlFiles, 0, "Should find 0 YAML files in empty directory")
+
+	_, processed, skipped := processYAMLFiles(yamlFiles, tmpDir, make(map[string]string), mockClient, false)
+	assert.Equal(t, 0, processed)
+	assert.Equal(t, 0, skipped)
+}
+
+// TestIntegrationModelAvailability tests the model availability check.
+func TestIntegrationModelAvailability(t *testing.T) {
+	mockClient := NewMockOllamaClient()
+	mockClient.AvailableModels = []string{DefaultModelName}
+
+	// Test with available model
+	response, err := mockClient.List(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, response.Models, 1)
+	assert.Equal(t, DefaultModelName, response.Models[0].Name)
+
+	// Test with unavailable model
+	mockClient.AvailableModels = []string{"other-model"}
+	response, err = mockClient.List(context.Background())
+	assert.NoError(t, err)
+	modelAvailable := false
+	for _, model := range response.Models {
+		if model.Name == DefaultModelName {
+			modelAvailable = true
+			break
+		}
+	}
+	assert.False(t, modelAvailable, "Default model should not be available")
+}

--- a/cmd/mock_ollama_client.go
+++ b/cmd/mock_ollama_client.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+
+	ollama "github.com/ollama/ollama/api"
+)
+
+// MockOllamaClient is a mock implementation of OllamaClient for testing.
+type MockOllamaClient struct {
+	// Map of file content snippets to mock summaries
+	MockResponses map[string]string
+	// Default response if no match is found
+	DefaultResponse string
+	// Available models to return from List()
+	AvailableModels []string
+}
+
+// NewMockOllamaClient creates a new MockOllamaClient with default responses.
+func NewMockOllamaClient() *MockOllamaClient {
+	return &MockOllamaClient{
+		MockResponses:   make(map[string]string),
+		DefaultResponse: "This is a mock summary for testing purposes.",
+		AvailableModels: []string{DefaultModelName},
+	}
+}
+
+// Chat implements OllamaClient.Chat for the mock.
+func (m *MockOllamaClient) Chat(ctx context.Context, req *ollama.ChatRequest, fn func(ollama.ChatResponse) error) error {
+	// Extract the YAML content from the request
+	var content string
+	if len(req.Messages) > 0 {
+		content = req.Messages[0].Content
+	}
+
+	// Find a matching mock response based on content
+	summary := m.DefaultResponse
+	for key, response := range m.MockResponses {
+		if strings.Contains(content, key) {
+			summary = response
+			break
+		}
+	}
+
+	// Call the callback function with the mock response
+	resp := ollama.ChatResponse{
+		Message: ollama.Message{
+			Content: summary,
+		},
+	}
+	return fn(resp)
+}
+
+// List implements OllamaClient.List for the mock.
+func (m *MockOllamaClient) List(ctx context.Context) (*ollama.ListResponse, error) {
+	models := make([]ollama.ListModelResponse, len(m.AvailableModels))
+	for i, modelName := range m.AvailableModels {
+		models[i] = ollama.ListModelResponse{
+			Name: modelName,
+		}
+	}
+	return &ollama.ListResponse{
+		Models: models,
+	}, nil
+}
+

--- a/cmd/ollama_client.go
+++ b/cmd/ollama_client.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"context"
+
+	ollama "github.com/ollama/ollama/api"
+)
+
+// OllamaClient defines the interface for interacting with Ollama.
+// This allows us to mock the client for testing purposes.
+type OllamaClient interface {
+	Chat(ctx context.Context, req *ollama.ChatRequest, fn func(ollama.ChatResponse) error) error
+	List(ctx context.Context) (*ollama.ListResponse, error)
+}
+
+// RealOllamaClient is a wrapper around the actual Ollama client that implements OllamaClient.
+type RealOllamaClient struct {
+	client *ollama.Client
+}
+
+// NewRealOllamaClient creates a new RealOllamaClient from the environment.
+func NewRealOllamaClient() (*RealOllamaClient, error) {
+	client, err := ollama.ClientFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	return &RealOllamaClient{client: client}, nil
+}
+
+// Chat implements OllamaClient.Chat
+func (r *RealOllamaClient) Chat(ctx context.Context, req *ollama.ChatRequest, fn func(ollama.ChatResponse) error) error {
+	return r.client.Chat(ctx, req, fn)
+}
+
+// List implements OllamaClient.List
+func (r *RealOllamaClient) List(ctx context.Context) (*ollama.ListResponse, error) {
+	return r.client.List(ctx)
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ func cleanSummary(summary string) string {
 }
 
 // summarizeYAMLFile uses Ollama to generate a short summary for a YAML file.
-func summarizeYAMLFile(ctx context.Context, client *ollama.Client, file string) (string, error) {
+func summarizeYAMLFile(ctx context.Context, client OllamaClient, file string) (string, error) {
 	content, err := os.ReadFile(file)
 	if err != nil {
 		return "", fmt.Errorf("failed to read %s: %w", file, err)
@@ -297,7 +297,7 @@ func writeIndividualSummary(baseDir, filePath, summary string) error {
 }
 
 // processYAMLFiles processes YAML files, generating summaries if needed, and returns the summaries map and counters.
-func processYAMLFiles(yamlFiles []string, dir string, existingSummaries map[string]string, client *ollama.Client, forceRegenerate bool) (map[string]string, int, int) {
+func processYAMLFiles(yamlFiles []string, dir string, existingSummaries map[string]string, client OllamaClient, forceRegenerate bool) (map[string]string, int, int) {
 	summaries := make(map[string]string)
 	skipped := 0
 	processed := 0
@@ -336,10 +336,11 @@ func runSummarizeYaml(dir string) error {
 	}
 	mdPath := filepath.Join(dir, MarkdownFileName)
 	existingSummaries := parseExistingSummaries(mdPath)
-	client, err := ollama.ClientFromEnvironment()
+	realClient, err := NewRealOllamaClient()
 	if err != nil {
 		return fmt.Errorf("failed to create Ollama client: %w", err)
 	}
+	client := OllamaClient(realClient)
 
 	// Check if the model is available
 	response, err := client.List(context.Background())


### PR DESCRIPTION
I'm adding some integration testing for this repo that mocks out the ollama client.

**Testing infrastructure and integration tests:**

* Added new file `cmd/integration_test.go` containing extensive integration tests for the CLI, covering end-to-end flows, the `--regenerate` flag, hidden directories, markdown output format, summary cleaning, empty directories, and model availability.
* Added `cmd/mock_ollama_client.go`, providing a `MockOllamaClient` implementation for use in tests, enabling simulation of Ollama responses and model availability.
* Introduced `cmd/ollama_client.go` defining the `OllamaClient` interface and a real client wrapper, allowing dependency injection and easy swapping between real and mock clients.

**Codebase modifications for testability:**

* Refactored `summarizeYAMLFile` and `processYAMLFiles` in `cmd/root.go` to accept an `OllamaClient` interface instead of a concrete Ollama client, enabling use of mocks in tests. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL89-R89) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL300-R300)
* Updated the instantiation of the Ollama client in `runSummarizeYaml` to use the new interface and wrapper, further decoupling the code from the concrete implementation.

**Developer workflow improvements:**

* Updated the Makefile to add an `integration-test` target, which runs the new integration tests, and clarified the `test` target as unit tests. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L16-R16) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L32-R37)
* Updated the GitHub Actions workflow (`.github/workflows/pre-main.yml`) to run both unit and integration tests in CI.
* Improved documentation in `README.md` to describe the new Makefile targets and clarify their usage.