### PR TITLE
Update Go to 1.25.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/yaml-to-readme
 
-go 1.25.1
+go 1.25.3
 
 require (
 	github.com/ollama/ollama v0.12.5


### PR DESCRIPTION
This PR updates the Go version to 1.25.3.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3273