### PR TITLE
Update Go to v1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/yaml-to-readme
 
-go 1.25.6
+go 1.26.0
 
 require (
 	github.com/ollama/ollama v0.15.6


### PR DESCRIPTION
## Summary
- Update Go version to 1.26.0
- [Go 1.26 Release Notes](https://go.dev/doc/go1.26)

## Test plan
- [x] go mod tidy succeeds
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs
- [mirrorbot#21](https://github.com/sebrandon1/mirrorbot/pull/21)
- [imagecertinfo-operator#36](https://github.com/sebrandon1/imagecertinfo-operator/pull/36)
- [yaml-to-readme#82](https://github.com/sebrandon1/yaml-to-readme/pull/82)
- [testapp#3](https://github.com/sebrandon1/testapp/pull/3)
- [jiracrawler#40](https://github.com/sebrandon1/jiracrawler/pull/40)
- [go-quay#74](https://github.com/sebrandon1/go-quay/pull/74)
- [go-dci#93](https://github.com/sebrandon1/go-dci/pull/93)